### PR TITLE
Fix running the sample on all PHP versions

### DIFF
--- a/ApnsPHP/Message.php
+++ b/ApnsPHP/Message.php
@@ -130,19 +130,19 @@ class Message
      * Custom message identifier.
      * @var string
      */
-    protected string $customIdentifier;
+    protected string $customIdentifier = '';
 
     /**
      * The topic of the remote notification, which is typically the bundle ID for your app.
      * @var string
      */
-    protected string $topic;
+    protected string $topic = '';
 
     /**
      * The collapse ID of the remote notification.
      * @var string
      */
-    protected string $collapseId;
+    protected string $collapseId = '';
 
     /**
      * The priority of the remote notification.

--- a/sample_push.php
+++ b/sample_push.php
@@ -30,7 +30,7 @@ require_once 'vendor/autoload.php';
 
 class SampleLogger extends \Psr\Log\AbstractLogger
 {
-	public function log($level, $message, array $context = array())
+	public function log($level, $message, array $context = array()): void
 	{
 		printf("%s: %s ApnsPHP[%d]: %s\n", date('r'), strtoupper($level), getmypid(), trim($message));
 	}

--- a/sample_push_custom.php
+++ b/sample_push_custom.php
@@ -30,7 +30,7 @@ require_once 'vendor/autoload.php';
 
 class SampleLogger extends \Psr\Log\AbstractLogger
 {
-	public function log($level, $message, array $context = array())
+	public function log($level, $message, array $context = array()): void
 	{
 		printf("%s: %s ApnsPHP[%d]: %s\n", date('r'), strtoupper($level), getmypid(), trim($message));
 	}

--- a/sample_push_http.php
+++ b/sample_push_http.php
@@ -30,7 +30,7 @@ require_once 'vendor/autoload.php';
 
 class SampleLogger extends \Psr\Log\AbstractLogger
 {
-	public function log($level, $message, array $context = array())
+	public function log($level, $message, array $context = array()): void
 	{
 		printf("%s: %s ApnsPHP[%d]: %s\n", date('r'), strtoupper($level), getmypid(), trim($message));
 	}

--- a/sample_push_many.php
+++ b/sample_push_many.php
@@ -33,7 +33,7 @@ require_once 'vendor/autoload.php';
 
 class SampleLogger extends \Psr\Log\AbstractLogger
 {
-	public function log($level, $message, array $context = array())
+	public function log($level, $message, array $context = array()): void
 	{
 		printf("%s: %s ApnsPHP[%d]: %s\n", date('r'), strtoupper($level), getmypid(), trim($message));
 	}

--- a/sample_push_safari.php
+++ b/sample_push_safari.php
@@ -30,7 +30,7 @@ require_once 'vendor/autoload.php';
 
 class SampleLogger extends \Psr\Log\AbstractLogger
 {
-	public function log($level, $message, array $context = array())
+	public function log($level, $message, array $context = array()): void
 	{
 		printf("%s: %s ApnsPHP[%d]: %s\n", date('r'), strtoupper($level), getmypid(), trim($message));
 	}


### PR DESCRIPTION
Initialize the string properties of the `Message` class so the `empty()` checks in the `Push` class work as intended.
Make the logger in the examples compatible with newer versions of `psr/log`