### PR TITLE
PHPStan level 6 fixes

### DIFF
--- a/ApnsPHP/Message.php
+++ b/ApnsPHP/Message.php
@@ -33,13 +33,13 @@ class Message
 
     /**
      * Supported notification priorities.
-     * @var array
+     * @var int[]
      */
     protected const APNS_PRIORITIES = [ 1, 5, 10 ];
 
     /**
      * Supported push types.
-     * @var array
+     * @var string[]
      */
     protected const APNS_PUSH_TYPES = [
         'alert',
@@ -60,7 +60,7 @@ class Message
 
     /**
      * Recipients device tokens.
-     * @var array
+     * @var string[]
      */
     protected array $deviceTokens = [];
 
@@ -116,7 +116,7 @@ class Message
 
     /**
      * Custom properties container.
-     * @var array
+     * @var array<string,mixed>
      */
     protected array $customProperties = [];
 
@@ -247,7 +247,7 @@ class Message
     /**
      * Get all recipients.
      *
-     * @return array Array of all recipients device token.
+     * @return string[] Array of all recipients device token.
      */
     public function getRecipients(): array
     {
@@ -477,7 +477,7 @@ class Message
     /**
      * Get all custom properties names.
      *
-     * @return array All properties names.
+     * @return string[] All properties names.
      */
     public function getCustomPropertyNames(): array
     {
@@ -543,7 +543,7 @@ class Message
      * For more information on push titles see:
      * https://stackoverflow.com/questions/40647061/bold-or-other-formatting-in-ios-push-notification
      *
-     * @return array The payload dictionary.
+     * @return array<string,mixed> The payload dictionary.
      */
     protected function getPayloadDictionary(): array
     {

--- a/ApnsPHP/Message/Tests/CustomMessageGetTest.php
+++ b/ApnsPHP/Message/Tests/CustomMessageGetTest.php
@@ -21,7 +21,7 @@ class CustomMessageGetTest extends CustomMessageTest
      *
      * @covers \ApnsPHP\Message\CustomMessage::getActionLocKey
      */
-    public function testGetActionLocKey()
+    public function testGetActionLocKey(): void
     {
         $this->set_reflection_property_value('actionLocKey', 'My Action');
 
@@ -35,7 +35,7 @@ class CustomMessageGetTest extends CustomMessageTest
      *
      * @covers \ApnsPHP\Message\CustomMessage::getLocKey
      */
-    public function testGetLocKey()
+    public function testGetLocKey(): void
     {
         $this->set_reflection_property_value('locKey', 'My Alert');
 
@@ -49,7 +49,7 @@ class CustomMessageGetTest extends CustomMessageTest
      *
      * @covers \ApnsPHP\Message\CustomMessage::getLocArgs
      */
-    public function testGetLocArgs()
+    public function testGetLocArgs(): void
     {
         $this->set_reflection_property_value('locArgs', [ 'args' ]);
 
@@ -63,7 +63,7 @@ class CustomMessageGetTest extends CustomMessageTest
      *
      * @covers \ApnsPHP\Message\CustomMessage::getLaunchImage
      */
-    public function testGetLaunchImage()
+    public function testGetLaunchImage(): void
     {
         $this->set_reflection_property_value('launchImage', 'my-image');
 
@@ -77,7 +77,7 @@ class CustomMessageGetTest extends CustomMessageTest
      *
      * @covers \ApnsPHP\Message\CustomMessage::getSubTitle
      */
-    public function testGetSubTitle()
+    public function testGetSubTitle(): void
     {
         $this->set_reflection_property_value('subTitle', 'My amazing notification');
 

--- a/ApnsPHP/Message/Tests/SafariMessageGetTest.php
+++ b/ApnsPHP/Message/Tests/SafariMessageGetTest.php
@@ -21,7 +21,7 @@ class SafariMessageGetTest extends SafariMessageTest
      *
      * @covers \ApnsPHP\Message\SafariMessage::getAction
      */
-    public function testGetAction()
+    public function testGetAction(): void
     {
         $this->set_reflection_property_value('action', 'My Action');
 
@@ -35,7 +35,7 @@ class SafariMessageGetTest extends SafariMessageTest
      *
      * @covers \ApnsPHP\Message\SafariMessage::getUrlArgs
      */
-    public function testGetUrlArgs()
+    public function testGetUrlArgs(): void
     {
         $this->set_reflection_property_value('urlArgs', [ 'args' ]);
 

--- a/ApnsPHP/Tests/MessageGetPayloadTest.php
+++ b/ApnsPHP/Tests/MessageGetPayloadTest.php
@@ -161,7 +161,7 @@ class MessageGetPayloadTest extends MessageTest
      *
      * @return string String of certain size in bytes
      */
-    private function getLargeString($size)
+    private function getLargeString($size): string
     {
         $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $length     = strlen($characters);

--- a/ApnsPHP/Tests/MessageGetTest.php
+++ b/ApnsPHP/Tests/MessageGetTest.php
@@ -21,7 +21,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getText
      */
-    public function testGetText()
+    public function testGetText(): void
     {
         $this->set_reflection_property_value('text', 'My Message');
 
@@ -35,7 +35,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getTitle
      */
-    public function testGetTitle()
+    public function testGetTitle(): void
     {
         $this->set_reflection_property_value('title', 'My Title');
 
@@ -49,7 +49,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getBadge
      */
-    public function testGetBadge()
+    public function testGetBadge(): void
     {
         $this->set_reflection_property_value('badge', 2);
 
@@ -63,7 +63,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getSound
      */
-    public function testGetSound()
+    public function testGetSound(): void
     {
         $this->set_reflection_property_value('sound', 'jingle');
 
@@ -77,7 +77,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCategory
      */
-    public function testGetCategory()
+    public function testGetCategory(): void
     {
         $this->set_reflection_property_value('category', 'news-1');
 
@@ -91,7 +91,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getThreadId
      */
-    public function testGetThreadId()
+    public function testGetThreadId(): void
     {
         $this->set_reflection_property_value('threadId', 'news-1');
 
@@ -105,7 +105,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getContentAvailable
      */
-    public function testGetContentAvailable()
+    public function testGetContentAvailable(): void
     {
         $this->set_reflection_property_value('contentAvailable', true);
 
@@ -119,7 +119,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getMutableContent
      */
-    public function testGetMutableContent()
+    public function testGetMutableContent(): void
     {
         $this->set_reflection_property_value('mutableContent', true);
 
@@ -133,7 +133,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getAutoAdjustLongPayload
      */
-    public function testGetAutoAdjustLongPayload()
+    public function testGetAutoAdjustLongPayload(): void
     {
         $this->set_reflection_property_value('autoAdjustLongPayload', false);
 
@@ -147,7 +147,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getExpiry
      */
-    public function testGetExpiry()
+    public function testGetExpiry(): void
     {
         $this->set_reflection_property_value('expiryValue', 600);
 
@@ -161,7 +161,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getTopic
      */
-    public function testGetTopic()
+    public function testGetTopic(): void
     {
         $this->set_reflection_property_value('topic', 'My App');
 
@@ -175,7 +175,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCollapseId
      */
-    public function testGetCollapseId()
+    public function testGetCollapseId(): void
     {
         $this->set_reflection_property_value('collapseId', 'news-1');
 
@@ -189,7 +189,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getPriority
      */
-    public function testGetPriority()
+    public function testGetPriority(): void
     {
         $this->set_reflection_property_value('priority', 5);
 
@@ -203,7 +203,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getPushType
      */
-    public function testGetPushType()
+    public function testGetPushType(): void
     {
         $this->set_reflection_property_value('pushType', 'alert');
 
@@ -217,7 +217,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomIdentifier
      */
-    public function testGetCustomIdentifier()
+    public function testGetCustomIdentifier(): void
     {
         $this->set_reflection_property_value('customIdentifier', '3491ac4b-0681-4c92-8308-d8d8441f4e64');
 
@@ -231,7 +231,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomPropertyName
      */
-    public function testGetCustomPropertyNameReturnsFirstPropertyName()
+    public function testGetCustomPropertyNameReturnsFirstPropertyName(): void
     {
         $properties = [
             'my-title'   => 'My Title',
@@ -250,7 +250,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomPropertyName
      */
-    public function testGetCustomPropertyNameThrowsExceptionWhenNoneSet()
+    public function testGetCustomPropertyNameThrowsExceptionWhenNoneSet(): void
     {
         $this->expectException('ApnsPHP\Message\Exception');
         $this->expectExceptionMessage('No custom property exists!');
@@ -263,7 +263,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomPropertyValue
      */
-    public function testGetCustomPropertyValueReturnsFirstPropertyValue()
+    public function testGetCustomPropertyValueReturnsFirstPropertyValue(): void
     {
         $properties = [
             'my-title'   => 'My Title',
@@ -282,7 +282,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomPropertyValue
      */
-    public function testGetCustomPropertyValueThrowsExceptionWhenNoneSet()
+    public function testGetCustomPropertyValueThrowsExceptionWhenNoneSet(): void
     {
         $this->expectException('ApnsPHP\Message\Exception');
         $this->expectExceptionMessage('No custom property exists!');
@@ -295,7 +295,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomProperty
      */
-    public function testGetCustomPropertyWithExistingPropertyName()
+    public function testGetCustomPropertyWithExistingPropertyName(): void
     {
         $properties = [
             'my-title'   => 'My Title',
@@ -314,7 +314,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomProperty
      */
-    public function testGetCustomPropertyThrowsExceptionWhenNotExists()
+    public function testGetCustomPropertyThrowsExceptionWhenNotExists(): void
     {
         $properties = [
             'my-title'   => 'My Title',
@@ -334,7 +334,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomPropertyNames
      */
-    public function testGetCustomPropertyNamesWithPropertiesSet()
+    public function testGetCustomPropertyNamesWithPropertiesSet(): void
     {
         $properties = [
             'my-title'   => 'My Title',
@@ -353,7 +353,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getCustomPropertyNames
      */
-    public function testGetCustomPropertyNamesWithoutPropertiesSet()
+    public function testGetCustomPropertyNamesWithoutPropertiesSet(): void
     {
         $value = $this->class->getCustomPropertyNames();
 
@@ -365,7 +365,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getRecipientsNumber
      */
-    public function testGetRecipientsNumber()
+    public function testGetRecipientsNumber(): void
     {
         $tokens = [
             '1e82db91c7ceddd72bf33d74ae052ac9c84a065b35148ac401388843106a7485L',
@@ -384,7 +384,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getRecipientsCount
      */
-    public function testGetRecipientsCount()
+    public function testGetRecipientsCount(): void
     {
         $tokens = [
             '1e82db91c7ceddd72bf33d74ae052ac9c84a065b35148ac401388843106a7485L',
@@ -403,7 +403,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getRecipients
      */
-    public function testGetRecipients()
+    public function testGetRecipients(): void
     {
         $tokens = [
             '1e82db91c7ceddd72bf33d74ae052ac9c84a065b35148ac401388843106a7485L',
@@ -422,7 +422,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getRecipient
      */
-    public function testGetExistingRecipient()
+    public function testGetExistingRecipient(): void
     {
         $tokens = [
             '1e82db91c7ceddd72bf33d74ae052ac9c84a065b35148ac401388843106a7485L',
@@ -441,7 +441,7 @@ class MessageGetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::getRecipient
      */
-    public function testGetOutOfBoundsRecipient()
+    public function testGetOutOfBoundsRecipient(): void
     {
         $tokens = [
             '1e82db91c7ceddd72bf33d74ae052ac9c84a065b35148ac401388843106a7485L',

--- a/ApnsPHP/Tests/MessageSetTest.php
+++ b/ApnsPHP/Tests/MessageSetTest.php
@@ -21,7 +21,7 @@ class MessageSetTest extends MessageTest
      *
      * @return array Variations of the reserved apple namespace key
      */
-    public function reservedAppleNamespaceKeyProvider()
+    public function reservedAppleNamespaceKeyProvider(): array
     {
         $data   = [];
         $data[] = [ 'aps' ];
@@ -37,7 +37,7 @@ class MessageSetTest extends MessageTest
      *
      * @return array Variations of valid custom identifiers
      */
-    public function validCustomIdentifierProvider()
+    public function validCustomIdentifierProvider(): array
     {
         $data   = [];
         $data[] = [ '3491ac4b-0681-4c92-8308-d8d8441f4e64' ];
@@ -51,7 +51,7 @@ class MessageSetTest extends MessageTest
      *
      * @return array Variations of a valid message priority
      */
-    public function validPriorityProvider()
+    public function validPriorityProvider(): array
     {
         $data   = [];
         $data[] = [ 1 ];
@@ -66,7 +66,7 @@ class MessageSetTest extends MessageTest
      *
      * @return array Variations of a valid push type
      */
-    public function validPushTypeProvider()
+    public function validPushTypeProvider(): array
     {
         $data   = [];
         $data[] = [ 'alert' ];
@@ -86,7 +86,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setText
      */
-    public function testSetText()
+    public function testSetText(): void
     {
         $this->class->setText('My Message');
 
@@ -98,7 +98,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setTitle
      */
-    public function testSetTitle()
+    public function testSetTitle(): void
     {
         $this->class->setTitle('My Title');
 
@@ -110,7 +110,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setBadge
      */
-    public function testSetBadge()
+    public function testSetBadge(): void
     {
         $this->class->setBadge(2);
 
@@ -122,7 +122,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setSound
      */
-    public function testSetSound()
+    public function testSetSound(): void
     {
         $this->class->setSound('jingle');
 
@@ -134,7 +134,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setSound
      */
-    public function testSetDefaultSound()
+    public function testSetDefaultSound(): void
     {
         $this->class->setSound();
 
@@ -146,7 +146,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setCategory
      */
-    public function testSetCategory()
+    public function testSetCategory(): void
     {
         $this->class->setCategory('news');
 
@@ -158,7 +158,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setCategory
      */
-    public function testSetDefaultCategory()
+    public function testSetDefaultCategory(): void
     {
         $this->class->setCategory();
 
@@ -170,7 +170,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setThreadId
      */
-    public function testSetThreadId()
+    public function testSetThreadId(): void
     {
         $this->class->setThreadId('news-1');
 
@@ -182,7 +182,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setThreadId
      */
-    public function testSetDefaultThreadId()
+    public function testSetDefaultThreadId(): void
     {
         $this->class->setThreadId();
 
@@ -194,7 +194,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setContentAvailable
      */
-    public function testSetContentAvailableTrue()
+    public function testSetContentAvailableTrue(): void
     {
         $this->class->setContentAvailable(true);
 
@@ -206,7 +206,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setContentAvailable
      */
-    public function testSetContentAvailableFalse()
+    public function testSetContentAvailableFalse(): void
     {
         $this->class->setContentAvailable(false);
 
@@ -218,7 +218,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setContentAvailable
      */
-    public function testSetDefaultContentAvailable()
+    public function testSetDefaultContentAvailable(): void
     {
         $this->class->setContentAvailable(true);
 
@@ -230,7 +230,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setMutableContent
      */
-    public function testSetMutableContentTrue()
+    public function testSetMutableContentTrue(): void
     {
         $this->class->setMutableContent(true);
 
@@ -242,7 +242,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setMutableContent
      */
-    public function testSetMutableContentFalse()
+    public function testSetMutableContentFalse(): void
     {
         $this->class->setMutableContent(false);
 
@@ -254,7 +254,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setMutableContent
      */
-    public function testSetDefaultMutableContent()
+    public function testSetDefaultMutableContent(): void
     {
         $this->class->setMutableContent();
 
@@ -266,7 +266,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setAutoAdjustLongPayload
      */
-    public function testSetAutoAdjustLongPayload()
+    public function testSetAutoAdjustLongPayload(): void
     {
         $this->class->setAutoAdjustLongPayload(false);
 
@@ -278,7 +278,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setExpiry
      */
-    public function testSetExpiry()
+    public function testSetExpiry(): void
     {
         $this->class->setExpiry(600);
 
@@ -290,7 +290,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setTopic
      */
-    public function testSetTopic()
+    public function testSetTopic(): void
     {
         $this->class->setTopic('My App');
 
@@ -302,7 +302,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setCollapseId
      */
-    public function testSetCollapseId()
+    public function testSetCollapseId(): void
     {
         $this->class->setCollapseId('news-1');
 
@@ -314,7 +314,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setCustomProperty
      */
-    public function testSetCustomProperty()
+    public function testSetCustomProperty(): void
     {
         $this->class->setCustomProperty('myId', 'my-news-1');
 
@@ -326,7 +326,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setCustomProperty
      */
-    public function testSetAdditionalCustomProperty()
+    public function testSetAdditionalCustomProperty(): void
     {
         $this->set_reflection_property_value('customProperties', [ 'myId' => 'my-news-1' ]);
 
@@ -348,7 +348,7 @@ class MessageSetTest extends MessageTest
      * @dataProvider reservedAppleNamespaceKeyProvider
      * @covers       \ApnsPHP\Message::setCustomProperty
      */
-    public function testSetInvalidCustomProperty(string $key)
+    public function testSetInvalidCustomProperty(string $key): void
     {
         $this->expectException('ApnsPHP\Message\Exception');
         $this->expectExceptionMessage("Property name 'aps' can not be used for custom property.");
@@ -364,7 +364,7 @@ class MessageSetTest extends MessageTest
      * @dataProvider validCustomIdentifierProvider
      * @covers       \ApnsPHP\Message::setCustomIdentifier
      */
-    public function testSetValidCustomIndentifier(string $id)
+    public function testSetValidCustomIndentifier(string $id): void
     {
         $this->class->setCustomIdentifier($id);
 
@@ -376,7 +376,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setCustomIdentifier
      */
-    public function testSetInvalidCustomIndentifier()
+    public function testSetInvalidCustomIndentifier(): void
     {
         $this->expectException('ApnsPHP\Message\Exception');
         $this->expectExceptionMessage('Identifier must be a UUID');
@@ -392,7 +392,7 @@ class MessageSetTest extends MessageTest
      * @dataProvider validPriorityProvider
      * @covers       \ApnsPHP\Message::setPriority
      */
-    public function testSetValidPriority(int $priority)
+    public function testSetValidPriority(int $priority): void
     {
         $this->class->setPriority($priority);
 
@@ -404,7 +404,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setPriority
      */
-    public function testSetInvalidPriority()
+    public function testSetInvalidPriority(): void
     {
         $this->expectException('ApnsPHP\Message\Exception');
         $this->expectExceptionMessage('Invalid priority');
@@ -420,7 +420,7 @@ class MessageSetTest extends MessageTest
      * @dataProvider validPushTypeProvider
      * @covers       \ApnsPHP\Message::setPushType
      */
-    public function testSetValidPushType(string $type)
+    public function testSetValidPushType(string $type): void
     {
         $this->class->setPushType($type);
 
@@ -432,7 +432,7 @@ class MessageSetTest extends MessageTest
      *
      * @covers \ApnsPHP\Message::setPushType
      */
-    public function testSetInvalidPushType()
+    public function testSetInvalidPushType(): void
     {
         $this->expectException('ApnsPHP\Message\Exception');
         $this->expectExceptionMessage('Invalid push type');

--- a/ApnsPHP/Tests/PushAddTest.php
+++ b/ApnsPHP/Tests/PushAddTest.php
@@ -21,7 +21,7 @@ class PushAddTest extends PushTest
      *
      * @covers \ApnsPHP\Push::add
      */
-    public function testAddOneMessage()
+    public function testAddOneMessage(): void
     {
         $this->message->expects($this->once())
                       ->method('getPayLoad')
@@ -48,7 +48,7 @@ class PushAddTest extends PushTest
      *
      * @covers \ApnsPHP\Push::add
      */
-    public function testAddMultipleMessages()
+    public function testAddMultipleMessages(): void
     {
         $messages = [
             1 => [ 'MESSAGE' => $this->message, 'ERRORS' => [] ],
@@ -82,7 +82,7 @@ class PushAddTest extends PushTest
      *
      * @covers \ApnsPHP\Push::add
      */
-    public function testAddDoesNothing()
+    public function testAddDoesNothing(): void
     {
         $this->message->expects($this->once())
                       ->method('getPayLoad')

--- a/ApnsPHP/Tests/PushConnectTest.php
+++ b/ApnsPHP/Tests/PushConnectTest.php
@@ -24,7 +24,7 @@ class PushConnectTest extends PushTest
      *
      * @covers \ApnsPHP\Push::connect
      */
-    public function testConnectSuccess()
+    public function testConnectSuccess(): void
     {
         $this->set_reflection_property_value('logger', $this->logger);
 
@@ -54,7 +54,7 @@ class PushConnectTest extends PushTest
      *
      * @covers \ApnsPHP\Push::connect
      */
-    public function testConnectThrowsExceptionOnHttpInitFail()
+    public function testConnectThrowsExceptionOnHttpInitFail(): void
     {
         $this->set_reflection_property_value('connectRetryInterval', 0);
         $this->set_reflection_property_value('logger', $this->logger);

--- a/ApnsPHP/Tests/PushDisconnectTest.php
+++ b/ApnsPHP/Tests/PushDisconnectTest.php
@@ -21,7 +21,7 @@ class PushDisconnectTest extends PushTest
      *
      * @covers \ApnsPHP\Push::disconnect
      */
-    public function testDisconnectSuccess()
+    public function testDisconnectSuccess(): void
     {
         $this->set_reflection_property_value('hSocket', curl_init());
         $this->set_reflection_property_value('logger', $this->logger);
@@ -40,7 +40,7 @@ class PushDisconnectTest extends PushTest
      *
      * @covers \ApnsPHP\Push::disconnect
      */
-    public function testDisconnectReturnsFalse()
+    public function testDisconnectReturnsFalse(): void
     {
         $result = $this->class->disconnect();
 

--- a/ApnsPHP/Tests/PushGetTest.php
+++ b/ApnsPHP/Tests/PushGetTest.php
@@ -21,7 +21,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getSendRetryTimes
      */
-    public function testGetSendRetryTimes()
+    public function testGetSendRetryTimes(): void
     {
         $value = $this->class->getSendRetryTimes();
 
@@ -33,7 +33,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getWriteInterval
      */
-    public function testGetWriteInterval()
+    public function testGetWriteInterval(): void
     {
         $value = $this->class->getWriteInterval();
 
@@ -45,7 +45,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getConnectTimeout
      */
-    public function testGetConnectTimeout()
+    public function testGetConnectTimeout(): void
     {
         $value = $this->class->getConnectTimeout();
 
@@ -57,7 +57,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getConnectRetryTimes
      */
-    public function testGetConnectRetryTimes()
+    public function testGetConnectRetryTimes(): void
     {
         $value = $this->class->getConnectRetryTimes();
 
@@ -69,7 +69,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getConnectRetryInterval
      */
-    public function testGetConnectRetryInterval()
+    public function testGetConnectRetryInterval(): void
     {
         $value = $this->class->getConnectRetryInterval();
 
@@ -81,7 +81,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getMessageQueue
      */
-    public function testGetMessageQueue()
+    public function testGetMessageQueue(): void
     {
         $this->set_reflection_property_value('messageQueue', [ 'queue' ]);
 
@@ -97,7 +97,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getMessageQueue
      */
-    public function testGetMessageQueueEmptiesQueue()
+    public function testGetMessageQueueEmptiesQueue(): void
     {
         $this->set_reflection_property_value('messageQueue', [ 'queue' ]);
 
@@ -113,7 +113,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getErrors
      */
-    public function testGetErrors()
+    public function testGetErrors(): void
     {
         $this->set_reflection_property_value('errors', [ 'errors' ]);
 
@@ -129,7 +129,7 @@ class PushGetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::getErrors
      */
-    public function testGetErrorsEmptiesErrors()
+    public function testGetErrorsEmptiesErrors(): void
     {
         $this->set_reflection_property_value('errors', [ 'errors' ]);
 

--- a/ApnsPHP/Tests/PushHttpInitTest.php
+++ b/ApnsPHP/Tests/PushHttpInitTest.php
@@ -26,7 +26,7 @@ class PushHttpInitTest extends PushTest
      *
      * @covers \ApnsPHP\Push::httpInit
      */
-    public function testHttpInitSucceedsWithCertificate()
+    public function testHttpInitSucceedsWithCertificate(): void
     {
         $this->set_reflection_property_value('providerCertFile', 'cert.pem');
         $this->set_reflection_property_value('logger', $this->logger);
@@ -52,7 +52,7 @@ class PushHttpInitTest extends PushTest
      *
      * @covers \ApnsPHP\Push::httpInit
      */
-    public function testHttpInitSucceedsWithKey()
+    public function testHttpInitSucceedsWithKey(): void
     {
         $this->set_reflection_property_value('providerCertFile', 'key.p8');
         $this->set_reflection_property_value('providerTeamId', 'TheTeam');
@@ -128,7 +128,7 @@ class PushHttpInitTest extends PushTest
      *
      * @covers \ApnsPHP\Push::httpInit
      */
-    public function testHttpInitThrowsExceptionOnCurlSetoptFail()
+    public function testHttpInitThrowsExceptionOnCurlSetoptFail(): void
     {
         $this->set_reflection_property_value('providerCertFile', 'key.p8');
         $this->set_reflection_property_value('providerTeamId', 'TheTeam');

--- a/ApnsPHP/Tests/PushHttpSendTest.php
+++ b/ApnsPHP/Tests/PushHttpSendTest.php
@@ -20,7 +20,7 @@ class PushHttpSendTest extends PushTest
      * Helper function to set the http headers and verify calls to message getters
      * These calls happen when HttpSend is called and can be the same every time
      */
-    private function setHttpHeaders()
+    private function setHttpHeaders(): void
     {
         $this->message->expects($this->exactly(2))
                       ->method('getTopic')
@@ -54,7 +54,7 @@ class PushHttpSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::httpSend
      */
-    public function testHttpSendReturnsFalseOnCurlSessionFail()
+    public function testHttpSendReturnsFalseOnCurlSessionFail(): void
     {
         $this->mock_function('curl_exec', function () {
             return false;
@@ -88,7 +88,7 @@ class PushHttpSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::httpSend
      */
-    public function testHttpSendReturnsFalseOnCurlOptsCannotBeSet()
+    public function testHttpSendReturnsFalseOnCurlOptsCannotBeSet(): void
     {
         $this->mock_function('curl_setopt_array', function () {
             return false;
@@ -126,7 +126,7 @@ class PushHttpSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::httpSend
      */
-    public function testHttpSendReturnsFalseOnRequestFail()
+    public function testHttpSendReturnsFalseOnRequestFail(): void
     {
         $this->mock_function('curl_setopt_array', function () {
             return true;
@@ -169,7 +169,7 @@ class PushHttpSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::httpSend
      */
-    public function testHttpSendReturnsTrueOnSuccess()
+    public function testHttpSendReturnsTrueOnSuccess(): void
     {
         $this->mock_function('curl_setopt_array', function () {
             return true;

--- a/ApnsPHP/Tests/PushInvalidTest.php
+++ b/ApnsPHP/Tests/PushInvalidTest.php
@@ -31,7 +31,7 @@ class PushInvalidTest extends PushTest
      *
      * @covers \ApnsPHP\Push::__construct
      */
-    public function testConstructWithInvalidEnvironment()
+    public function testConstructWithInvalidEnvironment(): void
     {
         $this->expectException('ApnsPHP\Push\Exception');
         $this->expectExceptionMessage("Invalid environment '3'");
@@ -45,7 +45,7 @@ class PushInvalidTest extends PushTest
      *
      * @covers \ApnsPHP\Push::__construct
      */
-    public function testConstructWithNonExistingProviderCertificateFile()
+    public function testConstructWithNonExistingProviderCertificateFile(): void
     {
         $this->expectException('ApnsPHP\Push\Exception');
         $this->expectExceptionMessage("Unable to read certificate file 'server_certificates_bundle_invalid.pem'");
@@ -58,7 +58,7 @@ class PushInvalidTest extends PushTest
      *
      * @covers \ApnsPHP\Push::__construct
      */
-    public function testConstructWithUnreadableProviderCertificateFile()
+    public function testConstructWithUnreadableProviderCertificateFile(): void
     {
         $this->expectException('ApnsPHP\Push\Exception');
         $this->expectExceptionMessage("Unable to read certificate file 'server_certificates_bundle_unreadable.pem'");

--- a/ApnsPHP/Tests/PushRemoveMessageFromQueueTest.php
+++ b/ApnsPHP/Tests/PushRemoveMessageFromQueueTest.php
@@ -21,7 +21,7 @@ class PushRemoveMessageFromQueueTest extends PushTest
      *
      * @covers \ApnsPHP\Push::removeMessageFromQueue
      */
-    public function testRemoveMessageFromQueueThrowsExceptionOnInvalidMessageID()
+    public function testRemoveMessageFromQueueThrowsExceptionOnInvalidMessageID(): void
     {
         $this->expectException('ApnsPHP\Push\Exception');
         $this->expectExceptionMessage('Message ID format is not valid.');
@@ -35,7 +35,7 @@ class PushRemoveMessageFromQueueTest extends PushTest
      *
      * @covers \ApnsPHP\Push::removeMessageFromQueue
      */
-    public function testRemoveMessageFromQueueThrowsExceptionOnMissingMessageID()
+    public function testRemoveMessageFromQueueThrowsExceptionOnMissingMessageID(): void
     {
         $this->expectException('ApnsPHP\Push\Exception');
         $this->expectExceptionMessage('The Message ID 1 does not exists.');
@@ -49,7 +49,7 @@ class PushRemoveMessageFromQueueTest extends PushTest
      *
      * @covers \ApnsPHP\Push::removeMessageFromQueue
      */
-    public function testRemoveMessageFromQueueRemovesMessageFromQueue()
+    public function testRemoveMessageFromQueueRemovesMessageFromQueue(): void
     {
         $queue = [
             1 => [ 'MESSAGE' => $this->message, 'ERRORS' => [] ],
@@ -73,7 +73,7 @@ class PushRemoveMessageFromQueueTest extends PushTest
      *
      * @covers \ApnsPHP\Push::removeMessageFromQueue
      */
-    public function testRemoveMessageFromQueueRemovesMessageFromQueueAndAddsError()
+    public function testRemoveMessageFromQueueRemovesMessageFromQueueAndAddsError(): void
     {
         $queue = [
             1 => [ 'MESSAGE' => $this->message, 'ERRORS' => [] ],

--- a/ApnsPHP/Tests/PushSendTest.php
+++ b/ApnsPHP/Tests/PushSendTest.php
@@ -23,7 +23,7 @@ class PushSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::send
      */
-    public function testSendThrowsExceptionOnNoConnection()
+    public function testSendThrowsExceptionOnNoConnection(): void
     {
         $this->expectException('ApnsPHP\Push\Exception');
         $this->expectExceptionMessage('Not connected to Push Notification Service');
@@ -36,7 +36,7 @@ class PushSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::send
      */
-    public function testSendThrowsExceptionOnEmptyQueue()
+    public function testSendThrowsExceptionOnEmptyQueue(): void
     {
         $this->set_reflection_property_value('hSocket', new stdClass());
 
@@ -51,7 +51,7 @@ class PushSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::send
      */
-    public function testSendFailsWithoutRetrying()
+    public function testSendFailsWithoutRetrying(): void
     {
         $this->mock_function('curl_exec', function () {
             return false;
@@ -118,7 +118,7 @@ class PushSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::send
      */
-    public function testSendFailsWithRetrying()
+    public function testSendFailsWithRetrying(): void
     {
         $this->mock_function('curl_exec', function () {
             return false;
@@ -191,7 +191,7 @@ class PushSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::send
      */
-    public function testSendRemovesWhenNoError()
+    public function testSendRemovesWhenNoError(): void
     {
         $this->mock_function('curl_exec', function () {
             return false;
@@ -251,7 +251,7 @@ class PushSendTest extends PushTest
      *
      * @covers \ApnsPHP\Push::send
      */
-    public function testSendSuccessfullySends()
+    public function testSendSuccessfullySends(): void
     {
         $this->mock_function('curl_exec', function () {
             return true;

--- a/ApnsPHP/Tests/PushSetTest.php
+++ b/ApnsPHP/Tests/PushSetTest.php
@@ -21,7 +21,7 @@ class PushSetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::setSendRetryTimes
      */
-    public function testSetSendRetryTimes()
+    public function testSetSendRetryTimes(): void
     {
         $this->class->setSendRetryTimes(4);
 
@@ -33,7 +33,7 @@ class PushSetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::setProviderCertificatePassphrase
      */
-    public function testSetProviderCertificatePassphrase()
+    public function testSetProviderCertificatePassphrase(): void
     {
         $this->class->setProviderCertificatePassphrase('password');
 
@@ -45,7 +45,7 @@ class PushSetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::setTeamId
      */
-    public function testSetTeamId()
+    public function testSetTeamId(): void
     {
         $this->class->setTeamId('team1');
 
@@ -57,7 +57,7 @@ class PushSetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::setKeyId
      */
-    public function testSetKeyId()
+    public function testSetKeyId(): void
     {
         $this->class->setKeyId('key1');
 
@@ -69,7 +69,7 @@ class PushSetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::setWriteInterval
      */
-    public function testSetWriteInterval()
+    public function testSetWriteInterval(): void
     {
         $this->class->setWriteInterval(20000);
 
@@ -81,7 +81,7 @@ class PushSetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::setConnectTimeout
      */
-    public function testSetConnectTimeout()
+    public function testSetConnectTimeout(): void
     {
         $this->class->setConnectTimeout(20);
 
@@ -93,7 +93,7 @@ class PushSetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::setConnectRetryTimes
      */
-    public function testSetConnectRetryTimes()
+    public function testSetConnectRetryTimes(): void
     {
         $this->class->setConnectRetryTimes(4);
 
@@ -105,7 +105,7 @@ class PushSetTest extends PushTest
      *
      * @covers \ApnsPHP\Push::setConnectRetryInterval
      */
-    public function testSetConnectRetryInterval()
+    public function testSetConnectRetryInterval(): void
     {
         $this->class->setConnectRetryInterval(2000000);
 

--- a/ApnsPHP/Tests/PushUpdateQueueTest.php
+++ b/ApnsPHP/Tests/PushUpdateQueueTest.php
@@ -21,7 +21,7 @@ class PushUpdateQueueTest extends PushTest
      *
      * @covers \ApnsPHP\Push::updateQueue
      */
-    public function testUpdateQueueReturnsFalse()
+    public function testUpdateQueueReturnsFalse(): void
     {
         $method = $this->get_accessible_reflection_method('updateQueue');
         $result = $method->invoke($this->class);
@@ -34,7 +34,7 @@ class PushUpdateQueueTest extends PushTest
      *
      * @covers \ApnsPHP\Push::updateQueue
      */
-    public function testUpdateQueueSucceedsWithErrorMessageParameter()
+    public function testUpdateQueueSucceedsWithErrorMessageParameter(): void
     {
         $errorMessage = [
             'identifier' => 3,
@@ -83,7 +83,7 @@ class PushUpdateQueueTest extends PushTest
      *
      * @covers \ApnsPHP\Push::updateQueue
      */
-    public function testUpdateQueueDoesNotDeleteUnsentMessages()
+    public function testUpdateQueueDoesNotDeleteUnsentMessages(): void
     {
         $errorMessage = [
             'identifier' => 2,


### PR DESCRIPTION
Fix a couple (but not all) phpstan level 6 issues

- Add return types for all test methods
- Be more precise with array types in the Message class