### PR TITLE
Add CURL handler last error logging

### DIFF
--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -641,7 +641,7 @@ class Push
             $errorCode = curl_errno($this->hSocket);
 
             if ($errorCode > 0) {
-                $reply = sprintf('Response: %s; Error code: %d; Error message: %s.', $reply, $errorCode, curl_error($this->hSocket));
+                $this->logger->error(sprintf('HTTP request error code: %d; message: %s.', $errorCode, curl_error($this->hSocket)));
             }
 
             return false;

--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -638,6 +638,12 @@ class Push
             CURLOPT_POSTFIELDS => $message->getPayload()
             ]) && ($reply = curl_exec($this->hSocket)) !== false)
         ) {
+            $errorCode = curl_errno($this->hSocket);
+
+            if ($errorCode > 0) {
+                $reply = sprintf('Response: %s; Error code: %d; Error message: %s.', $reply, $errorCode, curl_error($this->hSocket));
+            }
+
             return false;
         }
 

--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -641,7 +641,10 @@ class Push
             $errorCode = curl_errno($this->hSocket);
 
             if ($errorCode > 0) {
-                $this->logger->error(sprintf('HTTP request error code: %d; message: %s.', $errorCode, curl_error($this->hSocket)));
+                $this->logger->error('HTTP request error code: {code}; message: {message}.', [
+                    'code' => $errorCode,
+                    'message' => curl_error($this->hSocket),
+                ]);
             }
 
             return false;

--- a/ApnsPHP/Tests/PushHttpSendTest.php
+++ b/ApnsPHP/Tests/PushHttpSendTest.php
@@ -104,7 +104,7 @@ class PushHttpSendTest extends PushTest
         });
 
         $this->mock_function('curl_error', function () {
-            return 'OpenSSL SSL_read: error:14094415:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired, errno 0';
+            return 'OpenSSL SSL_read: error:14094415:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired';
         });
 
         $this->set_reflection_property_value('environment', 1);

--- a/ApnsPHP/Tests/PushHttpSendTest.php
+++ b/ApnsPHP/Tests/PushHttpSendTest.php
@@ -99,6 +99,14 @@ class PushHttpSendTest extends PushTest
             return true;
         });
 
+        $this->mock_function('curl_errno', function () {
+            return 56;
+        });
+
+        $this->mock_function('curl_error', function () {
+            return 'OpenSSL SSL_read: error:14094415:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired, errno 0';
+        });
+
         $this->set_reflection_property_value('environment', 1);
 
         $this->setHttpHeaders();

--- a/ApnsPHP/Tests/PushSendTest.php
+++ b/ApnsPHP/Tests/PushSendTest.php
@@ -69,6 +69,12 @@ class PushSendTest extends PushTest
         $this->mock_function('curl_init', function () {
             return new stdClass();
         });
+        $this->mock_function('curl_errno', function () {
+            return 0;
+        });
+        $this->mock_function('curl_error', function () {
+            return '';
+        });
 
         $error = [
             'command' => 8,
@@ -205,6 +211,12 @@ class PushSendTest extends PushTest
         });
         $this->mock_function('curl_close', function () {
             return null;
+        });
+        $this->mock_function('curl_errno', function () {
+            return 0;
+        });
+        $this->mock_function('curl_error', function () {
+            return '';
         });
         $this->mock_function('curl_init', function () {
             return new stdClass();


### PR DESCRIPTION
Hi there! I improved the CURL request logging by adding the last error code and message. It would be useful for such cases as certificate expiration

```
Error number: 56, Error message: OpenSSL SSL_read: error:14094415:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired, errno 0.
```

Thank you in advance!