### PR TITLE
Push: Adapt JWT generation to be compatible with more versions of lcobucci/jwt

### DIFF
--- a/ApnsPHP/Tests/PushHttpInitTest.php
+++ b/ApnsPHP/Tests/PushHttpInitTest.php
@@ -68,8 +68,8 @@ class PushHttpInitTest extends PushTest
                         ->getMock();
 
         $token = new Plain(
-            new DataSet([ 'headers' ], 'eHeaders'),
-            new DataSet([ 'claims' ], 'eClaims'),
+            new DataSet([ 'headers' => 'foo' ], 'eHeaders'),
+            new DataSet([ 'claims' => 'bar' ], 'eClaims'),
             new Signature('signature', 'eSignature'),
         );
 
@@ -148,8 +148,8 @@ class PushHttpInitTest extends PushTest
                         ->getMock();
 
         $token = new Plain(
-            new DataSet([ 'headers' ], 'eHeaders'),
-            new DataSet([ 'claims' ], 'eClaims'),
+            new DataSet([ 'headers' => 'foo' ], 'eHeaders'),
+            new DataSet([ 'claims' => 'bar' ], 'eClaims'),
             new Signature('signature', 'eSignature'),
         );
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"lib-curl": ">=7.33.0",
 		"lib-openssl": "*",
 		"psr/log": ">=1.1",
-		"lcobucci/jwt": "~4.1.5"
+		"lcobucci/jwt": "~4.1 || ~5.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": ">=9.0 <9.6",


### PR DESCRIPTION
We could create the `Builder` directly, but the (albeit useless) roundtrip through `Configuration` makes this easier to test. 
Functionally nothing changes, since what's passed to `forSymmetricSigner()` isn't used for anything. Only what's passed to `getToken()` matters.