### PR TITLE
Push: Assign curl_exec() return to temporary variable

### DIFF
--- a/ApnsPHP/Tests/PushHttpSendTest.php
+++ b/ApnsPHP/Tests/PushHttpSendTest.php
@@ -96,7 +96,7 @@ class PushHttpSendTest extends PushTest
         });
 
         $this->mock_function('curl_exec', function () {
-            return true;
+            return '';
         });
 
         $this->mock_function('curl_errno', function () {
@@ -142,7 +142,7 @@ class PushHttpSendTest extends PushTest
         });
 
         $this->mock_function('curl_exec', function () {
-            return true;
+            return '';
         });
 
         $this->mock_function('curl_getinfo', function () {
@@ -185,7 +185,7 @@ class PushHttpSendTest extends PushTest
         });
 
         $this->mock_function('curl_exec', function () {
-            return true;
+            return '';
         });
 
         $this->mock_function('curl_getinfo', function () {

--- a/ApnsPHP/Tests/PushSendTest.php
+++ b/ApnsPHP/Tests/PushSendTest.php
@@ -267,7 +267,7 @@ class PushSendTest extends PushTest
     public function testSendSuccessfullySends(): void
     {
         $this->mock_function('curl_exec', function () {
-            return true;
+            return '';
         });
         $this->mock_function('curl_setopt_array', function () {
             return true;


### PR DESCRIPTION
This makes sure the string type of `$reply` is respected, even in cased when `curl_exec()` fails.