### PR TITLE
General: Fix phpstan level 6 issues

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -94,7 +94,7 @@ jobs:
         run: composer update
 
       - name: Run PHPStan
-        run: phpstan analyse ApnsPHP -l5
+        run: phpstan analyse ApnsPHP -l6
 
   conclusion:
     needs: [phpunit, phpcs, phpstan]

--- a/ApnsPHP/Message.php
+++ b/ApnsPHP/Message.php
@@ -20,6 +20,23 @@ use ApnsPHP\Message\PushType;
  * Notification Service.
  *
  * @see http://tinyurl.com/ApplePushNotificationPayload
+ *
+ * @phpstan-type PayloadDictionary ReservedPayloadDictionary&CustomPayloadDictionary
+ * @phpstan-type CustomPayloadDictionary array<string,scalar|array<array-key,mixed>>
+ * @phpstan-type ReservedPayloadDictionary array{
+ *     aps: array{
+ *         alert?: string|array{
+ *             title:string,
+ *             body:string
+ *         },
+ *         badge?: int,
+ *         sound?: string,
+ *         content-available?: int,
+ *         mutable-content?: int,
+ *         category?: string,
+ *         thread-id?: string,
+ *     },
+ * }
  */
 class Message
 {
@@ -99,7 +116,7 @@ class Message
 
     /**
      * Custom properties container.
-     * @var array<string,mixed>
+     * @var array<string,scalar|array<array-key,mixed>>
      */
     protected array $customProperties = [];
 
@@ -393,8 +410,8 @@ class Message
     /**
      * Set a custom property.
      *
-     * @param string $name  Custom property name.
-     * @param mixed  $value Custom property value.
+     * @param string                        $name  Custom property name.
+     * @param scalar|array<array-key,mixed> $value Custom property value.
      */
     public function setCustomProperty(string $name, $value): void
     {
@@ -422,9 +439,9 @@ class Message
      *
      * @param string $name Custom property name.
      *
-     * @return string The custom property value.
+     * @return scalar|array<array-key,mixed> The custom property value.
      */
-    public function getCustomProperty(string $name)
+    public function getCustomProperty(string $name): array|bool|float|int|string
     {
         if (!array_key_exists($name, $this->customProperties)) {
             throw new Exception(
@@ -476,7 +493,7 @@ class Message
      * For more information on push titles see:
      * https://stackoverflow.com/questions/40647061/bold-or-other-formatting-in-ios-push-notification
      *
-     * @return array<string,mixed> The payload dictionary.
+     * @return PayloadDictionary The payload dictionary.
      */
     protected function getPayloadDictionary(): array
     {

--- a/ApnsPHP/Message/CustomMessage.php
+++ b/ApnsPHP/Message/CustomMessage.php
@@ -18,6 +18,28 @@ use ApnsPHP\Message;
  * Please refer to Table 3-2 for more information.
  *
  * @see http://tinyurl.com/ApplePushNotificationPayload
+ *
+ * @phpstan-type PayloadDictionary ReservedPayloadDictionary&CustomPayloadDictionary
+ * @phpstan-type CustomPayloadDictionary array<string,scalar|array<array-key,mixed>>
+ * @phpstan-type ReservedPayloadDictionary array{
+ *     aps: array{
+ *         alert?: array{
+ *             body?: string,
+ *             action-loc-key?: ?non-empty-string,
+ *             loc-key?: string,
+ *             loc-args?: string[],
+ *             launch-image?: string,
+ *             title?: string,
+ *             subtitle?: string,
+ *         },
+ *         badge?: int,
+ *         sound?: string,
+ *         content-available?: int,
+ *         mutable-content?: int,
+ *         category?: string,
+ *         thread-id?: string,
+ *     },
+ * }
  */
 class CustomMessage extends Message
 {
@@ -35,7 +57,7 @@ class CustomMessage extends Message
 
     /**
      * Variable string values to appear in place of the format specifiers in loc-key.
-     * @var array
+     * @var string[]
      */
     protected array $locArgs;
 
@@ -105,7 +127,7 @@ class CustomMessage extends Message
      * Set the variable string values to appear in place of the format specifiers
      * in loc-key.
      *
-     * @param array $locArgs The variable string values.
+     * @param string[] $locArgs The variable string values.
      */
     public function setLocArgs(array $locArgs): void
     {
@@ -116,7 +138,7 @@ class CustomMessage extends Message
      * Get the variable string values to appear in place of the format specifiers
      * in loc-key.
      *
-     * @return array The variable string values.
+     * @return string[] The variable string values.
      */
     public function getLocArgs(): array
     {
@@ -173,7 +195,7 @@ class CustomMessage extends Message
     /**
      * Get the payload dictionary.
      *
-     * @return array The payload dictionary.
+     * @return PayloadDictionary The payload dictionary.
      */
     protected function getPayloadDictionary(): array
     {

--- a/ApnsPHP/Message/SafariMessage.php
+++ b/ApnsPHP/Message/SafariMessage.php
@@ -15,6 +15,17 @@ use ApnsPHP\Message;
  * The SafariMessage Push Notification Message.
  *
  * The class represents a SafariMessage Push Notification message.
+ *
+ * @phpstan-type PayloadDictionary array{
+ *     aps: array{
+ *         alert: array{
+ *             title?: string,
+ *             body?: string,
+ *             action?: string,
+ *             url-args?: string[],
+ *         },
+ *     },
+ * }
  */
 class SafariMessage extends Message
 {
@@ -26,7 +37,7 @@ class SafariMessage extends Message
 
     /**
      * Variable string values to appear in place of the format specifiers in urlFormatString.
-     * @var array
+     * @var string[]
      */
     protected array $urlArgs;
 
@@ -54,7 +65,7 @@ class SafariMessage extends Message
      * Set the variable string values to appear in place of the format specifiers
      * in urlFormatString.
      *
-     * @param array $urlArgs The variable string values.
+     * @param string[] $urlArgs The variable string values.
      */
     public function setUrlArgs(array $urlArgs): void
     {
@@ -65,7 +76,7 @@ class SafariMessage extends Message
      * Get the variable string values to appear in place of the format specifiers
      * in urlFormatString.
      *
-     * @return array The variable string values.
+     * @return string[] The variable string values.
      */
     public function getUrlArgs(): array
     {
@@ -75,7 +86,7 @@ class SafariMessage extends Message
     /**
      * Get the payload dictionary.
      *
-     * @return array The payload dictionary.
+     * @return PayloadDictionary The payload dictionary.
      */
     protected function getPayloadDictionary(): array
     {

--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -23,6 +23,16 @@ use Psr\Log\LoggerInterface;
  *
  * The class manages a message queue and sends notifications payload to Apple Push
  * Notification Service.
+ *
+ * @phpstan-type MessageError array{
+ *     identifier: string,
+ *     statusCode: int,
+ *     statusMessage: string,
+ * }
+ * @phpstan-type MessageEnvelope array{
+ *     MESSAGE: Message,
+ *     ERRORS: MessageError[]
+ * }
  */
 class Push
 {
@@ -141,13 +151,13 @@ class Push
 
     /**
      * Message queue.
-     * @var array
+     * @var MessageEnvelope[]
      */
     protected array $messageQueue = [];
 
     /**
      * Error container.
-     * @var array
+     * @var MessageEnvelope[]
      */
     protected array $errors = [];
 
@@ -626,7 +636,7 @@ class Push
      *
      * @param bool $empty Empty the message queue (optional).
      *
-     * @return array Array of messages left on the queue.
+     * @return MessageEnvelope[] Array of messages left on the queue.
      */
     public function getMessageQueue(bool $empty = true): array
     {
@@ -643,7 +653,7 @@ class Push
      *
      * @param bool $empty Empty the message container.
      *
-     * @return array Array of messages not delivered because one or more errors occurred.
+     * @return MessageEnvelope[] Array of messages not delivered because one or more errors occurred.
      */
     public function getErrors(bool $empty = true): array
     {
@@ -657,7 +667,7 @@ class Push
     /**
      * Checks for error message and deletes messages successfully sent from message queue.
      *
-     * @param array $errorMessages The error message (optional).
+     * @param MessageError $errorMessages The error message (optional).
      *
      * @return bool True if an error was received.
      */

--- a/ApnsPHP/Tests/MessageSetTest.php
+++ b/ApnsPHP/Tests/MessageSetTest.php
@@ -22,7 +22,7 @@ class MessageSetTest extends MessageTest
     /**
      * Unit test data provider for reserved apple namespace keys.
      *
-     * @return array Variations of the reserved apple namespace key
+     * @return array<string[]> Variations of the reserved apple namespace key
      */
     public function reservedAppleNamespaceKeyProvider(): array
     {
@@ -38,7 +38,7 @@ class MessageSetTest extends MessageTest
     /**
      * Unit test data provider for valid custom identifiers.
      *
-     * @return array Variations of valid custom identifiers
+     * @return array<string[]> Variations of valid custom identifiers
      */
     public function validCustomIdentifierProvider(): array
     {
@@ -52,7 +52,7 @@ class MessageSetTest extends MessageTest
     /**
      * Unit test data provider for valid message priorities.
      *
-     * @return array Variations of a valid message priority
+     * @return array<Priority[]> Variations of a valid message priority
      */
     public function validPriorityProvider(): array
     {
@@ -67,7 +67,7 @@ class MessageSetTest extends MessageTest
     /**
      * Unit test data provider for valid push types.
      *
-     * @return array Variations of a valid push type
+     * @return array<PushType[]> Variations of a valid push type
      */
     public function validPushTypeProvider(): array
     {


### PR DESCRIPTION
phpstan seems to have issues with the intersection type `ReservedPayloadDictionary&CustomPayloadDictionary`, since higher phpstan levels issue this error:

```
Method ApnsPHP\Message::getPayloadDictionary() should return array{aps: array{alert?: array{title: string, body: string}|string, badge?: int, sound?: string, content-available?: int, mutable-content?: int, category?: string, thread-id?: string}} but returns non-empty-array<string, array<mixed>|bool|float|int|string>.
```
The actual return type should match the `CustomPayloadDictionary` part of the type definition, but that is completely absent in the expected type.

Additionally, the type `array<string,scalar|array<array-key,mixed>>` for `customProperties` is not correct, but I couldn't find a better definition for "value can be a scalar, or an array where values are scalars or an array where values are...", i.e. a recursive type definition.

Also, in case anyone has better suggestions for the type names, I'm all ears...